### PR TITLE
Combine home and away logo

### DIFF
--- a/po/haca.pot
+++ b/po/haca.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-01-16 10:34-0500\n"
+"POT-Creation-Date: 2015-01-16 12:11-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -26,6 +26,6 @@ msgid "Check current and recent hockey scores"
 msgstr ""
 
 #. Register a category for the current weather, with the title we just built
-#: ../src/scope/query.cpp:98
+#: ../src/scope/query.cpp:97
 msgid "Schedule"
 msgstr ""

--- a/src/scope/query.cpp
+++ b/src/scope/query.cpp
@@ -40,9 +40,8 @@ const static string TEMPLATE =
         "components": {
         "title": "title",
         "art" : {
-        "field": "awayLogo"
+        "field": "art"
         },
-        "mascot": "homeLogo",
         "subtitle": "subtitle"
         }
         }
@@ -107,13 +106,12 @@ void Query::run(sc::SearchReplyProxy const& reply) {
             res.set_uri(uri.arg(game.id).toStdString());
             res.set_title((game.away.name + " at " + game.home.name).toStdString());
 
-            std::string awayLogo = (config_->cache_dir.c_str() + game.away.name.toLower().replace(" ", "") + "_logo.svgz").toStdString();
-            std::string homeLogo = (config_->cache_dir.c_str() + game.home.name.toLower().replace(" ", "") + "_logo.svgz").toStdString();
+            QString away = game.away.name.toLower().replace(" ", "");
+            QString home = game.home.name.toLower().replace(" ", "");
+            std::string homeLogo = (config_->cache_dir.c_str() + away + "_" + home + ".svg").toStdString();
             // Set the rest of the attributes
             res["subtitle"] = game.start.toStdString();
             res["description"] = "";
-            res["awayLogo"] = awayLogo;
-            res["homeLogo"] = homeLogo;
             res.set_art(homeLogo);
 
             // Push the result


### PR DESCRIPTION
Currently the two logos are split between "art" and "mascot" items.  They look slightly different and only one can be shown when the game is selected, so it's better to combine them into the same image.
